### PR TITLE
Print report green if no failures

### DIFF
--- a/lib/fitting/log.rb
+++ b/lib/fitting/log.rb
@@ -96,7 +96,11 @@ module Fitting
       Fitting::Log.failure(logs).each_with_index do |log, index|
         puts "\e[31m  #{index + 1}) #{log.error.class} #{log.error.message}\n\n\e[0m"
       end
-      print "\e[31m#{logs.size} examples, #{Fitting::Log.failure(logs).size} failure, #{Fitting::Log.pending(logs).size} pending\e[0m\n"
+
+      failure_count = Fitting::Log.failure(logs).size
+      color_code = failure_count > 0 ? 31 : 32
+      print "\e[#{color_code}m#{logs.size} examples, #{failure_count} failure, #{Fitting::Log.pending(logs).size} pending\e[0m\n"
+
       unless Fitting::Log.failure(logs).size <= 0
         exit 1
       end


### PR DESCRIPTION
It was printing with red color even if the check was successful, and it's a bit confusing.
Let's print report in green, more like rspec

Before
![image](https://github.com/matchtechnologies/fitting/assets/9076531/6e9b6a3c-f835-4a59-ad5c-ff8f3509746c)

After
![image](https://github.com/matchtechnologies/fitting/assets/9076531/c287eec7-6258-4176-af82-1be211b20f04)
